### PR TITLE
Added recordingStatusChanged event

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -997,6 +997,21 @@ class API {
     }
 
     /**
+     * Notify external application (if API is enabled) that recording has started or stopped.
+     *
+     * @param {boolean} on - True if recording is on, false otherwise.
+     * @param {string} mode - Stream or file.
+     * @returns {void}
+     */
+    notifyRecordingStatusChanged(on: boolean, mode: string) {
+        this._sendEvent({
+            name: 'recording-status-changed',
+            on,
+            mode
+        });
+    }
+
+    /**
      * Disposes the allocated resources.
      *
      * @returns {void}

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -87,7 +87,8 @@ const events = {
     'dominant-speaker-changed': 'dominantSpeakerChanged',
     'subject-change': 'subjectChange',
     'suspend-detected': 'suspendDetected',
-    'tile-view-changed': 'tileViewChanged'
+    'tile-view-changed': 'tileViewChanged',
+    'recording-status-changed': 'recordingStatusChanged'
 };
 
 /**

--- a/react/features/recording/middleware.js
+++ b/react/features/recording/middleware.js
@@ -164,8 +164,9 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                     dispatch(showRecordingLimitNotification(mode));
                 }
 
-
                 sendAnalytics(createRecordingEvent('start', mode));
+
+                typeof APP === 'object' && APP.API.notifyRecordingStatusChanged(true, mode);
 
                 if (disableRecordAudioNotification) {
                     break;
@@ -192,7 +193,10 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                     duration
                         = (Date.now() / 1000) - oldSessionData.timestamp;
                 }
+
                 sendAnalytics(createRecordingEvent('stop', mode, duration));
+
+                typeof APP === 'object' && APP.API.notifyRecordingStatusChanged(false, mode);
 
                 if (disableRecordAudioNotification) {
                     break;


### PR DESCRIPTION
Now it's possible to subscribe to recordingStatusChanged event from Jitsi iFrame API.

const api = new JitsiMeetExternalAPI(domain, options);
api.on('recordingStatusChanged', handleApiEvent);
