### PR TITLE
Added recording started and stopped events to external API

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1009,6 +1009,32 @@ class API {
                 onDesktopSharingEnabledChanged);
         }
     }
+
+    /**
+     * Notify external application (if API is enabled) that recording has started.
+     *
+     *@param {string} mode - Stream or file.
+     * @returns {void}
+     */
+    notifyRecordingStarted(mode: string) {
+        this._sendEvent({
+            name: 'recording-started',
+            mode
+        });
+    }
+
+    /**
+     * Notify external application (if API is enabled) that recording has stopped.
+     *
+     *@param {string} mode - Stream or file.
+     * @returns {void}
+     */
+    notifyRecordingStopped(mode: string) {
+        this._sendEvent({
+            name: 'recording-stopped',
+            mode
+        });
+    }
 }
 
 export default new API();

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -87,7 +87,9 @@ const events = {
     'dominant-speaker-changed': 'dominantSpeakerChanged',
     'subject-change': 'subjectChange',
     'suspend-detected': 'suspendDetected',
-    'tile-view-changed': 'tileViewChanged'
+    'tile-view-changed': 'tileViewChanged',
+    'recording-started': 'recordingStarted',
+    'recording-stopped': 'recordingStopped'
 };
 
 /**


### PR DESCRIPTION
Fixes: https://github.com/jitsi/jitsi-meet/issues/7635

Added recordingStarted and recordingStopped events.
Now it's possible to listen to these events from Jitsi iFrame API.

```
const api = new JitsiMeetExternalAPI(domain, options);
api.on("recordingStarted", handleRecordingStarted);
api.on("recordingStopped", handleRecordingStopped);
```
